### PR TITLE
Remove SPS endpoint metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In your ```pom.xml``` file add the following:
 Usage example:
 
 ```java
-  unifiedPushClient = new UnifiedPushClient("http://localhost:8080/ag-push/rest/registry/device", "4f766e2c-b4da-42f5-8bfb-d7adc4030939",
+  UnifiedPushClient unifiedPushClient = new UnifiedPushClient("http://localhost:8080/ag-push/rest/registry/device", "4f766e2c-b4da-42f5-8bfb-d7adc4030939",
         "c9af3659-e7ce-4861-bcde-22b4b8b29492");
 
   client = new SimplePushClient("ws://localhost:7777/simplepush/websocket");
@@ -36,8 +36,7 @@ Usage example:
     @Override
     public void onRegistered(String channelId, String simplePushEndPoint) {
       final PushConfig config = new PushConfig();
-      config.setDeviceToken(channelId);
-      config.setSimplePushEndpoint(simplePushEndPoint);
+      config.setDeviceToken(simplePushEndPoint);
 
       unifiedPushClient.register(config);
     }

--- a/src/example/java/org/jboss/aerogear/simplepush/Usage.java
+++ b/src/example/java/org/jboss/aerogear/simplepush/Usage.java
@@ -48,8 +48,7 @@ public class Usage {
             @Override
             public void onRegistered(String channelId, String simplePushEndPoint) {
                 final PushConfig config = new PushConfig();
-                config.setDeviceToken(channelId);
-                config.setSimplePushEndpoint(simplePushEndPoint);
+                config.setDeviceToken(simplePushEndPoint);
 
                 config.setAlias("john");
                 config.setCategories(Arrays.asList("lead"));

--- a/src/main/java/org/jboss/aerogear/unifiedpush/PushConfig.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/PushConfig.java
@@ -25,7 +25,6 @@ public class PushConfig {
     private String deviceToken;
     private String alias;
     private List<String> categories;
-    private String simplePushEndpoint;
     private String operatingSystem;
     private String osVersion;
     private String deviceType;
@@ -56,14 +55,6 @@ public class PushConfig {
 
     public void setCategories(List<String> categories) {
         this.categories = categories;
-    }
-
-    public String getSimplePushEndpoint() {
-        return simplePushEndpoint;
-    }
-
-    public void setSimplePushEndpoint(String simplePushEndpoint) {
-        this.simplePushEndpoint = simplePushEndpoint;
     }
 
     public String getOperatingSystem() {

--- a/src/test/java/org/jboss/aerogear/unifiedpush/UnifiedPushClientTest.java
+++ b/src/test/java/org/jboss/aerogear/unifiedpush/UnifiedPushClientTest.java
@@ -39,7 +39,7 @@ public class UnifiedPushClientTest {
             }
         };
         PushConfig config = new PushConfig();
-        config.setSimplePushEndpoint(simplePushEndpoint);
+        config.setDeviceToken(simplePushEndpoint);
 
         //when
         client.register(config);


### PR DESCRIPTION
when sending `simplePushEndpoint` metadata, the server returns 400, since that attribute got removed before we released our 1.0.0

@sebastienblanc mind to review ? 